### PR TITLE
Limit FS permissions to desktop only

### DIFF
--- a/io.lbry.lbry-app.json
+++ b/io.lbry.lbry-app.json
@@ -25,6 +25,7 @@
 
         "--filesystem=xdg-desktop:rw",
         "--filesystem=xdg-download:rw",
+        "--filesystem=xdg-videos:rw",
 
         "--talk-name=org.freedesktop.secrets",
         "--talk-name=org.freedesktop.Notifications"

--- a/io.lbry.lbry-app.json
+++ b/io.lbry.lbry-app.json
@@ -16,19 +16,20 @@
     "finish-args": [
         "--share=ipc",
         "--share=network",
-        
+
         "--device=dri",
-        
+
         "--socket=x11",
         "--socket=wayland",
         "--socket=pulseaudio",
-        
-        "--filesystem=home:rw",
-        
+
+        "--filesystem=xdg-desktop:rw",
+        "--filesystem=xdg-download:rw",
+
         "--talk-name=org.freedesktop.secrets",
         "--talk-name=org.freedesktop.Notifications"
     ],
-    
+
     "modules": [
         {
             "name": "libsecret",


### PR DESCRIPTION
This limits the filesystem access to Desktop and Downloads.

Everything still works for me but you can now only upload from Desktop. Should we add xdg-videos as well?

Suggested as a fix for #12