### PR TITLE
[UPDATE] 0.38.2

### DIFF
--- a/io.lbry.lbry-app.appdata.xml
+++ b/io.lbry.lbry-app.appdata.xml
@@ -36,7 +36,7 @@
     <category>AudioVideo</category>
     <category>Video</category>
   </categories>
-  <url type="homepage">https://lbry.io/</url>
+  <url type="homepage">https://lbry.com/</url>
   <url type="bugtracker">https://github.com/lbryio/lbry-app/issues</url>
   <content_rating type="oars-1.1">
     <content_attribute id="violence-cartoon">none</content_attribute>
@@ -68,6 +68,48 @@
     <content_attribute id="money-gambling">none</content_attribute>
   </content_rating>
   <releases>
+         <release date="2019-12-21" version="0.38.2">
+          <description>
+            <p>Fixed:</p>
+            <ul>
+              <li>Always sync preferences on startup</li>
+              <li>App no longer crashes on edits in some cases</li>
+              <li>Sign in will no longer get stuck</li>
+            </ul>
+            </description>
+        </release>
+    <release date="2019-12-20" version="0.38.0">
+          <description>
+            <p>Fixed:</p>
+            <ul>
+              <li>Claim name changes on edits when reselecting a file</li>
+              <li>Crash when using localized settings on some machines</li>
+              <li>Crash on some old files without proper price</li>
+              <li>Don't filter own blocked/filtered content</li>
+              <li>Read preferences from wallet if not logged in</li>
+              <li>Balance checking on edits, check minimum</li>
+              <li>Message when no tags are selected</li>
+            </ul>
+            <p>Added:</p>
+            <ul>
+              <li>More languages; Dutch, Portugeese, Italian, Russian, Spanish, Gujarati, Hindi, Malay, Marathi, Panjabi, and Swedish</li>
+              <li>Dedicated Channel Creation page</li>
+              <li>Ability to use custom wallet servers</li>
+              <li>Autoplay free text files</li>
+              <li>Show thumbnail while playing audio files</li>
+              <li>Loading state for channels and publishes page</li>
+              <li>Channel thumbnails next to comments</li>
+            </ul>
+            <p>Changed:</p>
+            <ul>
+              <li>Better dark mode and minor design tweaks throughout the application</li>
+              <li>Updated lbry-sdk to 0.50.1</li>
+              <li>Always round down dates on claim previews for better youtube parity</li>
+              <li>Removed external link warning </li>
+              <li>Always show pause button when video is paused</li>
+            </ul>
+            </description>
+        </release>
          <release date="2019-11-21" version="0.37.2">
           <description>
             <p>Fixed:</p>

--- a/io.lbry.lbry-app.json
+++ b/io.lbry.lbry-app.json
@@ -70,15 +70,13 @@
                 "rm -f LBRY_*.deb",
                 "tar xf data.tar.xz",
                 "rm -f control.tar.gz data.tar.xz debian-binary",
-                "for DIR in usr/share/icons/hicolor/*; do cp $DIR/apps/LBRY.png $DIR/apps/lbry.png; done",
-                "sed -i 's|Exec=.*|Exec=/app/lbry-app/lbry-app|' usr/share/applications/LBRY.desktop",
-                "cp usr/share/applications/LBRY.desktop usr/share/applications/lbry.desktop",
-                "cp usr/share/applications/LBRY.desktop usr/share/applications/lbry-app.desktop",
+                "find usr/share/icons/hicolor/ -name 'LBRY.png' -type f -exec bash -c 'cp $0 ${0%LBRY.png}lbry.png' {} \\;",
+                "find usr/share/applications/ -name 'LBRY.desktop' -type f -exec bash -c 'sed -i \"s|Exec=.*|Exec=/app/lbry-app/lbry-app|\" $0; cp $0 ${0%lbry.desktop}lbry.desktop; cp $0 ${0%lbry.desktop}lbry.desktop' {} \\;",
                 "cp -r usr/* /app/",
                 "mkdir -p lbry-app",
                 "cp -r opt/LBRY /app/lbry-app",
                 "chmod -R a-s,go+rX,go-w /app/lbry-app",
-                "mv /app/lbry-app/LBRY /app/lbry-app/lbry-app",
+                "mv /app/lbry-app/lbry /app/lbry-app/lbry-app",
                 "install lbry-app.sh /app/bin/lbry-app",
                 "install -Dm644 io.lbry.lbry-app.appdata.xml /app/share/appdata/io.lbry.lbry-app.appdata.xml"
             ],
@@ -86,8 +84,8 @@
                 {
                     "type": "file",
                     "only-arches": ["x86_64"],
-                    "url": "https://github.com/lbryio/lbry-desktop/releases/download/v0.37.2/LBRY_0.37.2.deb",
-                    "sha256": "1db3a0ae8c5d26d4596ab0253439a37744376e0a343c29b08b3ba536501ca206"
+                    "url": "https://github.com/lbryio/lbry-desktop/releases/download/v0.38.2/LBRY_0.38.2.deb",
+                    "sha256": "dbb296fad36f77f8cf3354cfa67c6e836a20382ef34ee50f83d1aca7de001024"
                 },
                 {
                     "type": "script",


### PR DESCRIPTION
So this should be the working version of the previous update attempts. Small issues with the renaming of files and other awkwardness associated with case sensitivity of filenames on Linux resolved. Uses find to act as missing/misnamed file catching, should prevent build errors from previous attempts and make things more streamlined. I would recommend just being consistent with internal binary naming in future, either lbry, LBRY or lbry-app, not switching between several different ones dependent on packaging method.