### PR TITLE
Prevent display sleep when playing video

### DIFF
--- a/io.lbry.lbry-app.json
+++ b/io.lbry.lbry-app.json
@@ -26,6 +26,7 @@
         "--filesystem=home:rw",
 
         "--talk-name=org.gnome.SessionManager",
+        "--talk-name=org.freedesktop.ScreenSaver",
         "--talk-name=org.freedesktop.secrets",
         "--talk-name=org.freedesktop.Notifications"
     ],

--- a/io.lbry.lbry-app.json
+++ b/io.lbry.lbry-app.json
@@ -25,6 +25,7 @@
 
         "--filesystem=home:rw",
 
+        "--talk-name=org.gnome.SessionManager",
         "--talk-name=org.freedesktop.secrets",
         "--talk-name=org.freedesktop.Notifications"
     ],


### PR DESCRIPTION
This PR fixes an issue first raised [here](https://github.com/lbryio/lbry-desktop/issues/3789), in which the display sleeps when playing a video. Exposing these two services fixes the problem in Fedora KDE and Cinnamon.