### PR TITLE
Fix issue #63

### DIFF
--- a/io.lbry.lbry-app.json
+++ b/io.lbry.lbry-app.json
@@ -77,7 +77,7 @@
                     "type": "script",
                     "dest-filename": "lbry-app.sh",
                     "commands": [
-                        "exec /app/lbry-app/lbry-app \"$@\""
+                        "env TMPDIR=$XDG_RUNTIME_DIR/app/$FLATPAK_ID /app/lbry-app/lbry-app \"$@\""
                     ]
                 },
                 {


### PR DESCRIPTION
Fixes issue #63 .

Currently `lbry` will open another process even if it is already running. This is because it tries to put a lockfile in `/tmp`, which doesn't work.

As recommended in the Flatpak documentation [here](https://docs.flatpak.org/en/latest/sandbox-permissions.html):

> If an application uses `$TMPDIR` to contain lock files you may want to add a wrapper script that sets it to `$XDG_RUNTIME_DIR/app/$FLATPAK_ID`.

I tested on my computer and it seems to work fine.