### PR TITLE
Update Electron, libnotify, and libsecret

### DIFF
--- a/io.lbry.lbry-app.json
+++ b/io.lbry.lbry-app.json
@@ -35,17 +35,18 @@
         "shared-modules/libsecret/libsecret.json",
         {
             "name": "libnotify",
+            "buildsystem": "meson",
             "cleanup": [ "/bin" ],
             "config-opts": [
-                "--disable-static",
-                "--disable-tests",
-                "--disable-introspection"
+                "-Dman=false",
+                "-Dtests=false",
+                "-Dintrospection=disabled"
             ],
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/libnotify/0.7/libnotify-0.7.7.tar.xz",
-                    "sha256": "9cb4ce315b2655860c524d46b56010874214ec27e854086c1a1d0260137efc04"
+                    "url": "https://download.gnome.org/sources/libnotify/0.7/libnotify-0.7.9.tar.xz",
+                    "sha256": "66c0517ed16df7af258e83208faaf5069727dfd66995c4bbc51c16954d674761"
                 }
             ]
         },

--- a/io.lbry.lbry-app.json
+++ b/io.lbry.lbry-app.json
@@ -2,7 +2,7 @@
     "app-id": "io.lbry.lbry-app",
 
     "base": "io.atom.electron.BaseApp",
-    "base-version": "stable",
+    "base-version": "19.08",
 
     "runtime": "org.freedesktop.Platform",
     "runtime-version": "19.08",


### PR DESCRIPTION
Setting `stable` as `base-version` means that version 1.6 of `io.atom.electron.BaseApp` is used, which has been end-of-life for two years.

In any case, the freedesktop runtime and `io.atom.electron.BaseApp` should be using the same version to avoid compatibility issues.

Update `libnotify` to 0.7.9, and switch to the meson build system.

> `libnotify` 0.7.7 --> 0.7.9 :
> 
> * Support meson build system [Marco; !3]
> * notify-send: Support full URLs as hint values [Marco; !4]
> * Fixed linking in darwin [Iain, Marco; !5]
> * Added man page for notify-send [Jan; !6]
> * Dropped autotools [Jan; !11]
> * Mic. bug fixes [Ting-Wei, Florian; #760438, !8]
> 

Also update `libsecret` to 0.20.3.

> 
> `libsecret` 0.20.0 --> 0.20.3:
> 
>  * Build fixes [!45]
>  * secret-file-collection: force little-endian in GVariant [!49, #42]
>  * Prefer g_info() over g_message() [!48, #40]
>  * meson: Don't specify shared_library() [!47]
>  * docs: Make sure to set install: true [!46]
>  * secret-file-backend: Fix use-after-free in flatpak [!52]
>  * docs: Add man subdir only if manpage is enabled [!51]