### PR TITLE
Update base and add zypak-wrapper.

### DIFF
--- a/io.lbry.lbry-app.json
+++ b/io.lbry.lbry-app.json
@@ -1,7 +1,7 @@
 {
     "app-id": "io.lbry.lbry-app",
 
-    "base": "io.atom.electron.BaseApp",
+    "base": "org.electronjs.Electron2.BaseApp",
     "base-version": "19.08",
 
     "runtime": "org.freedesktop.Platform",
@@ -78,7 +78,7 @@
                     "type": "script",
                     "dest-filename": "lbry-app.sh",
                     "commands": [
-                        "env TMPDIR=$XDG_RUNTIME_DIR/app/$FLATPAK_ID /app/lbry-app/lbry-app \"$@\""
+                        "env TMPDIR=$XDG_RUNTIME_DIR/app/$FLATPAK_ID zypak-wrapper /app/lbry-app/lbry-app \"$@\""
                     ]
                 },
                 {


### PR DESCRIPTION
For any Electron apps >=v5 we need a wrapper. See: https://github.com/flatpak/flatpak/issues/3044

The new base image `org.electronjs.Electron2.BaseApp` seems to be maintained and has the wrapper already included.

`lbry-app` seems to hang when quitting after the `finished shutting down` event. Probably an error of `zypak-wrapper`.