### PR TITLE
Redirect .desktop file to launch script

### DIFF
--- a/io.lbry.lbry-app.json
+++ b/io.lbry.lbry-app.json
@@ -58,7 +58,7 @@
                 "rm -f LBRY_*.deb",
                 "tar xf data.tar.xz",
                 "rm -f control.tar.gz data.tar.xz debian-binary",
-                "find usr/share/applications/ -name 'lbry.desktop' -type f -exec sed -i 's|/.*/.*/lbry|/app/lbry-app/lbry-app|i' {} \\;",
+                "find usr/share/applications/ -name 'lbry.desktop' -type f -exec sed -i 's|/.*/.*/lbry|/app/bin/lbry-app|i' {} \\;",
                 "cp -r usr/* /app/",
                 "mkdir -p lbry-app",
                 "cp -r opt/LBRY /app/lbry-app",


### PR DESCRIPTION
The .desktop file was previously calling the app binary directly instead of the actual launch script in /app/bin, this corrects that issue, which should fix the missing wrapper call in issue #85 and make maintaining the binary call simpler in the future without requiring the maintainer mess with the sed command on line 61.