### PR TITLE
[UPDATE] 0.50.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,10 @@ flatpak install flathub io.lbry.lbry-app
 ## Building
 
 ```bash
+# See io.lbry.lbry-app.json for specific versions:
 flatpak install flathub org.freedesktop.Sdk
 flatpak install flathub org.freedesktop.Platform
-flatpak install flathub io.atom.electron.BaseApp
+flatpak install flathub org.electronjs.Electron2.BaseApp
 
 git clone https://github.com/flathub/io.lbry.lbry-app.git
 git submodule update --init --recursive

--- a/io.lbry.lbry-app.appdata.xml
+++ b/io.lbry.lbry-app.appdata.xml
@@ -71,7 +71,6 @@
       <release date="2021-02-26" version="0.50.1">
          <description>
             <p>Quick patch to fix the upgrade prompt extending beyond the height of the app. There were too many features and bug fixes to list properly!</p>
-            <p>https://twitter.com/LBRYcom/status/1372674409161498627</p>
          </description>
       </release>
       <release date="2021-02-26" version="0.50.0">

--- a/io.lbry.lbry-app.appdata.xml
+++ b/io.lbry.lbry-app.appdata.xml
@@ -68,6 +68,31 @@
       <content_attribute id="money-gambling">none</content_attribute>
    </content_rating>
    <releases>
+      <release date="2021-02-26" version="0.50.1">
+         <description>
+            <p>Quick patch to fix the upgrade prompt extending beyond the height of the app. There were too many features and bug fixes to list properly!</p>
+            <p>https://twitter.com/LBRYcom/status/1372674409161498627</p>
+         </description>
+      </release>
+      <release date="2021-02-26" version="0.50.0">
+         <description>
+            <p>Added:</p>
+            <ul>
+               <li>New moderation tools: block &amp; mute</li>
+               <li>Improved markdown file styling</li>
+               <li>Mass tip unlock</li>
+               <li>Zoomable image viewer in Markdown (posts and comments) community pr!</li>
+               <li>Enable PDF Viewer in App community pr!</li>
+               <li>The video/audio player's control tooltip is now localized and includes hints for keyboard shortcuts</li>
+               <li>Finnish and Norwegian language support</li>
+            </ul>
+            <p>Changed:</p>
+            <ul>
+               <li>Updated lbry-sdk to 0.92.0</li>
+               <li>Re-enable PDF Viewer in desktop app community pr!</li>
+            </ul>
+         </description>
+      </release>
       <release date="2021-02-26" version="0.49.5">
          <description>
             <p>Fixed:</p>

--- a/io.lbry.lbry-app.json
+++ b/io.lbry.lbry-app.json
@@ -71,8 +71,8 @@
                 {
                     "type": "file",
                     "only-arches": ["x86_64"],
-                    "url": "https://github.com/lbryio/lbry-desktop/releases/download/v0.49.5/LBRY_0.49.5.deb",
-                    "sha256": "ae0706949d2bd00d872cbb27b2485ea016d3964abe2993bc293de47dffc4f3aa"
+                    "url": "https://github.com/lbryio/lbry-desktop/releases/download/v0.50.1/LBRY_0.50.1.deb",
+                    "sha256": "152094499655c70c6757d9a72e029cad3ade4d290bbd79d9a4b9238b618947fe"
                 },
                 {
                     "type": "script",


### PR DESCRIPTION
Updating the lbry client to 0.50.1

I've also tweaked the README so the correct Electron package is given (this is the one in the .json manifest used for building)