### PR TITLE
Update LBRY to 0.51.1 version

### DIFF
--- a/io.lbry.lbry-app.appdata.xml
+++ b/io.lbry.lbry-app.appdata.xml
@@ -68,6 +68,14 @@
       <content_attribute id="money-gambling">none</content_attribute>
    </content_rating>
 <releases>
+      <release date="2021-06-26" version="0.51.1">
+        <description>
+            <p>Fixed:</p>
+            <ul>
+                <li>Enable sign up on desktop </li>
+            </ul>
+        </description>
+      </release>
       <release date="2021-04-02" version="0.50.2">
          <description>
             <p>Fixed:</p>

--- a/io.lbry.lbry-app.json
+++ b/io.lbry.lbry-app.json
@@ -71,8 +71,8 @@
                 {
                     "type": "file",
                     "only-arches": ["x86_64"],
-                    "url": "https://github.com/lbryio/lbry-desktop/releases/download/v0.50.2/LBRY_0.50.2.deb",
-                    "sha256": "f2f2792118a3595ac62c1f858d4fbde26dd055342be59fcf92b2279752127bd8"
+                    "url": "https://github.com/lbryio/lbry-desktop/releases/download/v0.51.1/LBRY_0.51.1.deb",
+                    "sha256": "a30087d96163e222c23cb128a8ab90f04fa34c8dc8915b345b72396036ce3eb3"
                 },
                 {
                     "type": "script",


### PR DESCRIPTION
Update to a new version to get rid of the warning in the app because the version is outdated.